### PR TITLE
Add support for AWS X-Forwarded-For overwrite

### DIFF
--- a/IPRotate.py
+++ b/IPRotate.py
@@ -99,7 +99,11 @@ class BurpExtender(IBurpExtender, IExtensionStateListener, ITab, IHttpListener):
 				restApiId=self.create_api_response['id'],
 				resourceId=get_resource_response['items'][0]['id'],
 				httpMethod='ANY',
-				authorizationType='NONE'
+				authorizationType='NONE',
+				requestParameters={
+					'method.request.path.proxy':True,
+					'method.request.header.X-My-X-Forwarded-For':True
+                                }
 			)
 
 			self.awsclient.put_integration(
@@ -109,7 +113,11 @@ class BurpExtender(IBurpExtender, IExtensionStateListener, ITab, IHttpListener):
 				httpMethod='ANY',
 				integrationHttpMethod='ANY',
 				uri=self.getTargetProtocol()+'://'+self.target_host.text + '/',
-				connectionType='INTERNET'
+				connectionType='INTERNET',
+				requestParameters={
+					'integration.request.path.proxy':'method.request.path.proxy',
+                                        'integration.request.header.X-Forwarded-For': 'method.request.header.X-My-X-Forwarded-For'
+				}
 			)
 
 			self.awsclient.put_method(
@@ -118,7 +126,8 @@ class BurpExtender(IBurpExtender, IExtensionStateListener, ITab, IHttpListener):
 				httpMethod='ANY',
 				authorizationType='NONE',
 				requestParameters={
-					'method.request.path.proxy':True
+					'method.request.path.proxy':True,
+					'method.request.header.X-My-X-Forwarded-For':True
 				}
 			)
 
@@ -131,7 +140,8 @@ class BurpExtender(IBurpExtender, IExtensionStateListener, ITab, IHttpListener):
 				uri= self.getTargetProtocol()+'://'+self.target_host.text+'/{proxy}',
 				connectionType= 'INTERNET',
 				requestParameters={
-					'integration.request.path.proxy':'method.request.path.proxy'
+					'integration.request.path.proxy':'method.request.path.proxy',
+                                        'integration.request.header.X-Forwarded-For': 'method.request.header.X-My-X-Forwarded-For'
 				}
 			)
 


### PR DESCRIPTION
I was having some trouble getting requests to actually register as a different IP through the API Gateway because it adds an X-Forwarded-For header to anything that goes through it. 

These changes will overwrite that if the API Gateway receives a request with an `X-My-X-Forwarded-For` header added.  You can put anything you want in the header (I just put the work "junk"), and with a Match/Replace rule in Burp it's pretty easy.

The idea for this was taken from the fireprox repo at [https://github.com/ustayready/fireprox](https://github.com/ustayready/fireprox)