### PR TITLE
Add delete_usage_plan

### DIFF
--- a/IPRotate.py
+++ b/IPRotate.py
@@ -185,6 +185,11 @@ class BurpExtender(IBurpExtender, IExtensionStateListener, ITab, IHttpListener):
 					restApiId=self.enabled_regions[region]
 				)
 				print response
+
+				self.awsclient.delete_usage_plan(
+					usagePlanId=self.usage_response['id']
+				)
+
 		self.enabled_regions = {}
 		self.allEndpoints = []
 		return


### PR DESCRIPTION
AWS API Gateway usage plan wasn't deleted.
Therefore, there were debris of usage plan like following picture.

![Screenshot from 2020-10-17 06-17-48](https://user-images.githubusercontent.com/47276120/96311995-a57aac00-1045-11eb-910f-3de855f149b7.png)


I added delete usage plan method for it.